### PR TITLE
Update protocol.rb

### DIFF
--- a/lib/software_challenge_client/protocol.rb
+++ b/lib/software_challenge_client/protocol.rb
@@ -184,7 +184,9 @@ class Protocol
         attribute = case action.type
                     when :acceleration
                       { acc: action.acceleration }
-                    when :push, :turn
+                    when :push
+                      { direction: action.direction.key }
+                    when :turn
                       { direction: action.direction }
                     when :advance
                       { distance: action.distance }

--- a/lib/software_challenge_client/protocol.rb
+++ b/lib/software_challenge_client/protocol.rb
@@ -187,7 +187,7 @@ class Protocol
                     when :push
                       { direction: action.direction.key }
                     when :turn
-                      { direction: action.direction }
+                      { direction: action.turn_steps }
                     when :advance
                       { distance: action.distance }
                     when default


### PR DESCRIPTION
direction is instance of Direction, XML-Attribute needs to be element of Directions key
rename Turn.direction to turn_steps due to misleading attribute name